### PR TITLE
Enforce aspect ratio when factor ratio given

### DIFF
--- a/classes/ResponsivePics.php
+++ b/classes/ResponsivePics.php
@@ -634,11 +634,11 @@ if (!class_exists('ResponsivePics')) {
 					$ratio = $original_width / $original_height;
 
 					if ($crop_ratio) {
-						$ratio       = $original_width / ($original_width * $crop_ratio);
-						$new_height  = $original_width * $crop_ratio;
+						$ratio           = $original_width / ($original_width * $crop_ratio);
+						$cropped_height  = $original_width * $crop_ratio;
 						// check if new height will be enough to get the right aspect ratio
-						$new_width   = $new_height <= $original_height ? $original_width : $original_height * $ratio;
-						$resized_url = self::get_resized_url($id, $file_path, $url, $new_width, $new_height, $crop);
+						$cropped_width   = $cropped_height <= $original_height ? $original_width : $original_height * $ratio;
+						$resized_url     = self::get_resized_url($id, $file_path, $url, $cropped_width, $cropped_height, $crop);
 					}
 
 					$source1x   = isset($resized_url) ? $resized_url : $url;

--- a/classes/ResponsivePics.php
+++ b/classes/ResponsivePics.php
@@ -634,8 +634,11 @@ if (!class_exists('ResponsivePics')) {
 					$ratio = $original_width / $original_height;
 
 					if ($crop_ratio) {
-						$resized_url = self::get_resized_url($id, $file_path, $url, $original_width, $original_width * $crop_ratio, $crop);
 						$ratio       = $original_width / ($original_width * $crop_ratio);
+						$new_height  = $original_width * $crop_ratio;
+						// check if new height will be enough to get the right aspect ratio
+						$new_width   = $new_height <= $original_height ? $original_width : $original_height * $ratio;
+						$resized_url = self::get_resized_url($id, $file_path, $url, $new_width, $new_height, $crop);
 					}
 
 					$source1x   = isset($resized_url) ? $resized_url : $url;

--- a/classes/ResponsivePics.php
+++ b/classes/ResponsivePics.php
@@ -636,9 +636,15 @@ if (!class_exists('ResponsivePics')) {
 					if ($crop_ratio) {
 						$ratio           = $original_width / ($original_width * $crop_ratio);
 						$cropped_height  = $original_width * $crop_ratio;
+						$cropped_width   = $original_width;
+						
 						// check if new height will be enough to get the right aspect ratio
-						$cropped_width   = $cropped_height <= $original_height ? $original_width : $original_height * $ratio;
-						$resized_url     = self::get_resized_url($id, $file_path, $url, $cropped_width, $cropped_height, $crop);
+						if($cropped_height > $original_height) {
+							$cropped_height = $original_height;
+							$cropped_width  = $original_height * $ratio;
+						}
+				
+						$resized_url = self::get_resized_url($id, $file_path, $url, $cropped_width, $cropped_height, $crop);
 					}
 
 					$source1x   = isset($resized_url) ? $resized_url : $url;


### PR DESCRIPTION
This adds a check to make sure that both the height and width of the image
respects the aspect ratio given in the `factor` parameter. 

Currently WP is cropping to the original image's aspect ratio if the new height
is taller than the available height.