### PR TITLE
Return integer instead of boolean from uasort() callback

### DIFF
--- a/src/class-breakpoints.php
+++ b/src/class-breakpoints.php
@@ -126,6 +126,6 @@ class RP_Breakpoints extends ResponsivePics {
 		$index_a = array_search($a['breakpoint'], array_keys(self::$breakpoints));
 		$index_b = array_search($b['breakpoint'], array_keys(self::$breakpoints));
 
-		return $index_a > $index_b;
+		return $index_a > $index_b ? 1 : -1;
 	}
 }


### PR DESCRIPTION
PHP 8 compatibility. Same issue as #17 but with `uasort()` this time.