### PR TITLE
Use original image as 2x fallback

### DIFF
--- a/src/class-sources.php
+++ b/src/class-sources.php
@@ -43,13 +43,16 @@ class RP_Sources extends ResponsivePics {
 			// get resized url
 			$resized_url = $this->get_resized_url($id, $image_path, $image_url, $width, $height, $crop);
 			if ($resized_url) {
-				$source1x = $resized_url;
-				$source2x = null;
+				$size_2x_available = $width * 2 < $original_width && $height * 2 < $original_height;
 
-				// we can also resize for @2x
-				if ($width * 2 < $original_width && $height * 2 < $original_height) {
-					$resized_2x_url = $this->get_resized_url($id, $image_path, $image_url, $width, $height, $crop, 2);
-					$source2x       = $resized_2x_url ? $resized_2x_url : null;
+				$source1x = $resized_url;
+				$source2x = $size_2x_available
+					? $this->get_resized_url($id, $image_path, $image_url, $width, $height, $crop, 2)
+					: null;
+
+				// Use the original image url when it is larger than the current source being generated
+				if (!$source2x && $width < $original_width) {
+					$source2x = $image_url;
 				}
 
 				$breakpoint = $rule['breakpoint'];


### PR DESCRIPTION
Use the original image as 2x fallback when a 2x image can't be generated and the original is larger than the current image being generated.

Consider the following config:

```php
ResponsivePics::setBreakPoints([
        'xs' => 0,
        'sm' => 640,
        'md' => 778,
        'lg' => 1024,
        'xl' => 1280,
        'xxl' => 1536,
        'xxxl' => 1900,
]);

ResponsivePics::setGridWidths([
        'xs' => 640,
        'sm' => 778,
        'md' => 1024,
        'lg' => 1280,
        'xl' => 1536,
        'xxl' => 1900,
        'xxxl' => 2500
]);
```

An image uploaded with dimensions w 945px x h 1003px with sizes `xs-12, md-6` would result in the following output:

```html
<picture>
  <source media="(min-width: 1900px)" data-srcset="img-1250x1326.png" data-aspectratio="0.94268476621418" srcset="img-1250x1326.png">
  <source media="(min-width: 1536px)" data-srcset="img-950x1008.png" data-aspectratio="0.94246031746032" srcset="img-950x1008.png">
  <source media="(min-width: 1280px)" data-srcset="img-768x815.png" data-aspectratio="0.94233128834356" srcset="img-768x815.png">
  <source media="(min-width: 1024px)" data-srcset="img-640x679.png" data-aspectratio="0.94256259204713" srcset="img-640x679.png">
  <source media="(min-width: 778px)" data-srcset="img-512x543.png" data-aspectratio="0.94290976058932" srcset="img-512x543.png">
  <source media="(min-width: 640px)" data-srcset="img-778x825.png" data-aspectratio="0.9430303030303" srcset="img-778x825.png">
  <source media="(min-width: 0px)" data-srcset="img-2500x2653.png" data-aspectratio="0.94232943837165" srcset="img-2500x2653.png">
  <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" data-aspectratio="" alt="" class="intrinsic__item has-alpha lazyloaded" style="width:100%;">
</picture>
```

A lesser quality image is shown when viewing on a 2x device even though a higher res image is available. E.g On a screen 1280px - 1535px the media query is:

```html
  <source media="(min-width: 1280px)" data-srcset="img-768x815.png" data-aspectratio="0.94233128834356" srcset="img-768x815.png">
```
and the user is shown an image at 768x815 rather than 945x1003.

This pull request changes the behaviour so that the highest res photo will be used as the 2x version of the image.

Output after changes:

```html
<picture>
  <source media="(min-width: 1900px)" data-srcset="img-1250x1326.png" data-aspectratio="0.94268476621418" srcset="img-1250x1326.png">
  <source media="(min-width: 1536px)" data-srcset="img-950x1008.png" data-aspectratio="0.94246031746032" srcset="img-950x1008.png">
  <source media="(min-width: 1280px)" data-srcset="img-768x815.png 1x, img.png 2x" data-aspectratio="0.94233128834356" srcset="img-768x815.png 1x, img.png 2x">
  <source media="(min-width: 1024px)" data-srcset="img-640x679.png 1x, img.png 2x" data-aspectratio="0.94256259204713" srcset="img-640x679.png 1x, img.png 2x">
  <source media="(min-width: 778px)" data-srcset="img-512x543.png 1x, img.png 2x" data-aspectratio="0.94290976058932" srcset="img-512x543.png 1x, img.png 2x">
  <source media="(min-width: 640px)" data-srcset="img-778x825.png 1x, img.png 2x" data-aspectratio="0.9430303030303" srcset="img-778x825.png 1x, img.png 2x">
  <source media="(min-width: 0px)" data-srcset="img-2500x2653.png" data-aspectratio="0.94232943837165" srcset="img-2500x2653.png">
  <img data-aspectratio="" alt="" class="intrinsic__item has-alpha lazyloaded" style="width:100%;" src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==">
</picture>
```